### PR TITLE
Data type

### DIFF
--- a/build.cmd.hxml
+++ b/build.cmd.hxml
@@ -3,6 +3,7 @@
 -lib mo
 -lib klas
 -lib cmd
+-lib media-types
 -cp src
 -debug
 -neko bin/fisel.n

--- a/haxelib.json
+++ b/haxelib.json
@@ -12,6 +12,7 @@
 	"detox": "",
 	"uhu": "",
     "mo": "",
+	"media-types": "",
 	"klas": ""
   }
 }

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -101,6 +101,8 @@ class Fisel {
 		return result;
 	}
 	
+	public var data:StringMap<Dynamic> = new StringMap();
+	
 	/**
 	 * This HTML document.
 	 */

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -313,8 +313,12 @@ class Fisel {
 				
 				if (dataType.isText) switch (dataType.subtype) {
 					case DataType.TEXT:
-						point.replaceWith( fisel.document.find( point.attr( 'select' ) ).text().parse() );
-						matched.push( link );
+						var text = fisel.document.find( point.attr( 'select' ) );
+						if (text.length > 0) {
+							point.replaceWith( text.text().parse() );
+							matched.push( link );
+							
+						}
 						
 					case DataType.JSON:
 						

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -6,6 +6,7 @@ import byte.ByteData;
 import uhx.select.Html;
 import uhx.select.Json;
 import haxe.ds.StringMap;
+import uhx.lexer.MimeLexer;
 import uhx.lexer.SelectorParser;
 import uhx.lexer.CssLexer.CssSelectors;
 
@@ -91,6 +92,7 @@ class Fisel {
 	private static var _ignore:Array<String> = ['select', Data.TYPE, Data.TARGET];
 	private static var _targets:Array<String> = [Source.TEXT, Source.HTML, Source.JSON];
 	private static var _actions:Array<String> = [Action.COPY, Action.REMOVE];
+	private static var _mediaType:MediaType = new MediaType( [Keyword(Toplevel('text')), Keyword(Subtype('html'))] );
 	
 	/**
 	 * Goes through the `parent`'s referrers link list
@@ -302,7 +304,7 @@ class Fisel {
 		var insertionPoints:DOMCollection = null;
 		var parser:SelectorParser = new SelectorParser();
 		var matched:Array<Link> = [];
-		var dataType:MediaType;
+		var mediaType:MediaType;
 		var dataAction:Action;
 		var nodes:DOMCollection;
 		
@@ -312,12 +314,11 @@ class Fisel {
 			
 			for (point in insertionPoints) {
 				nodes = new DOMCollection();
-				selector = parser.toTokens( ByteData.ofString( point.attr( 'select' ) ), 'fisel-insert' );
 				
-				dataType = point.attr( Data.TYPE ) != '' ? point.attr( Data.TYPE ).toLowerCase() : 'text/html';
+				mediaType = point.attr( Data.TYPE ) != '' ? point.attr( Data.TYPE ).toLowerCase() : _mediaType;
 				dataAction = point.attr( Data.TARGET ) != '' ? point.attr( Data.TARGET ).toLowerCase() : Action.COPY;
 				
-				if (dataType.isText) switch (dataType.subtype) {
+				if (mediaType.isText) switch (mediaType.subtype) {
 					case Source.TEXT:
 						var text = fisel.document.find( point.attr( 'select' ) );
 						if (text.length > 0) {
@@ -342,6 +343,8 @@ class Fisel {
 						
 					case _:
 						// Implies Source.HTML or Source.XML
+						selector = parser.toTokens( ByteData.ofString( point.attr( 'select' ) ), 'fisel-insert' );
+						
 						if (isID( selector )) {
 							id = getID( selector );
 							

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -355,19 +355,9 @@ class Fisel {
 										node.setAttr( attribute.name, attribute.value );
 										
 									} else {
-										var separator = ' ';
-										var space = 0;
-										var dash = 0;
-										
-										for (char in node.attr( attribute.name ).split('')) switch (char) {
-											case ' ': space++;
-											case '-': dash++;
-											case _:
-										}
-										
-										if (space < dash) separator = '-';
-										
-										var nodeParts = node.attr( attribute.name ).split( separator );
+										var nodeAttribute = node.attr( attribute.name );
+										var separator = findSeparator( nodeAttribute );
+										var nodeParts = nodeAttribute.split( separator );
 										var pointParts = attribute.value.split( separator ).filter( function(s) {
 											return nodeParts.indexOf( s ) == -1;
 										} );
@@ -396,6 +386,23 @@ class Fisel {
 		// Remove any matched links so they do get processed in the
 		// next step.
 		for (match in matched) links.remove( match );
+	}
+	
+	/**
+	 * Crudely determines if a space ` ` or a dash `-` is
+	 * separating the values.
+	 */
+	private function findSeparator(value:String):String {
+		var space = 0;
+		var dash = 0;
+		
+		for (character in value.split('')) switch (character) {
+			case ' ': space++;
+			case '-': dash++;
+			case _:
+		}
+		
+		return space < dash ? '-' : ' ';
 	}
 	
 	private function isCombinator(selector:CssSelectors):Bool {
@@ -432,89 +439,6 @@ class Fisel {
 		
 		return result;
 	}
-	
-	/*public function build():Void {
-		/*for (key in importCache.keys()) importCache.get( key ).build();
-		
-		var attr;
-		var matches;
-		var targets;
-		for (content in insertionPoints) {
-			attr = content.attr( 'select' );
-			
-			if (attr.startsWith('#') && importCache.exists( attr.substring(1) )) {
-				content.replaceWith( 
-					importCache.get( attr = attr.substring(1) ).document.find( 'template:first-child' ).innerHTML().htmlUnescape().parse() 
-				);
-				
-			} else {
-				matches = document.find( attr );
-				
-				if (matches.length != 0) {
-					var attributes = [for (a in content.attributes) a].filter( 
-						function(a) {
-							a.name = a.name.startsWith('data-') ? a.name.substring(5) : a.name;
-							return _targets.indexOf(a.name) > -1 || _actions.indexOf(a.value) > -1;
-						}
-					);
-					
-					switch (attributes[0]) {
-						case { name:Target.TEXT, value:Action.MOVE }:
-							content.replaceWith( matches.text().parse() );
-							matches.remove();
-							
-						case { name:Target.TEXT, value:Action.COPY } | { name:Target.TEXT }:
-							content.replaceWith( matches.text().parse() );
-							
-						case { name:Target.JSON } :
-							
-							
-						case { name:Target.DOM, value:Action.MOVE } :
-							targets = matches;
-							content.replaceWith( targets );
-							
-						case { name:Target.DOM, value:Action.COPY } | { name:Target.DOM } | null | _:
-							targets = matches.clone();
-							content.replaceWith( targets );
-							
-					}
-					
-					attributes = [for (a in content.attributes) a].filter(
-						function(a) return _ignore.indexOf( a.name ) == -1
-					);
-					
-					var value;
-					var separator;
-					if (targets != null) {
-						for (target in targets) for (a in attributes) if ((value = target.attr( a.name )) == '') {
-							target.setAttr(a.name, a.value);
-							
-						} else if (value.indexOf( a.value ) == -1) {
-							separator = !value.startsWith('-') && value.indexOf('-') > -1? '-' : ' ';
-							target.setAttr( a.name, '$value$separator${a.value}' );
-							
-						}
-						
-						targets = null;
-						
-					}
-				}
-				
-			}
-			
-		}
-		
-		// Remove any unresolved `<content select="..." />`
-		document.find( 'content[select]' ).remove();
-		
-		// Remove all `<link rel="import" />`
-		imports.remove();*/
-		
-		/*for (link in links) {
-			if (!link.cycle) linkMap.get( link.location ).build();
-			
-		}
-	}*/
 	
 	#if !js
 	public inline function loadFile(path:String):Null<String> {

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -1,12 +1,13 @@
 package;
 
 import uhx.io.Uri;
-import uhx.lexer.CssLexer.CssSelectors;
-import uhx.lexer.SelectorParser;
 import uhx.mo.Token;
 import byte.ByteData;
 import uhx.select.Html;
+import uhx.select.Json;
 import haxe.ds.StringMap;
+import uhx.lexer.SelectorParser;
+import uhx.lexer.CssLexer.CssSelectors;
 
 using Fisel;
 using Detox;
@@ -308,21 +309,8 @@ class Fisel {
 				nodes = new DOMCollection();
 				selector = parser.toTokens( ByteData.ofString( point.attr( 'select' ) ), 'fisel-insert' );
 				
-				if (point.attr( 'data-type' ) != '') {
-					dataType = point.attr( 'data-type' ).toLowerCase();
-					
-				} else {
-					dataType = 'text/html';
-					
-				}
-				
-				if (point.attr( 'data-action' ) != '') {
-					dataAction = point.attr( 'data-action' ).toLowerCase();
-					
-				} else {
-					dataAction = DataAction.COPY;
-					
-				}
+				dataType = point.attr( 'data-type' ) != '' ? point.attr( 'data-type' ).toLowerCase() : 'text/html';
+				dataAction = point.attr( 'data-action' ) != '' ? point.attr( 'data-action' ).toLowerCase() : DataAction.COPY;
 				
 				if (dataType.isText) switch (dataType.subtype) {
 					case DataType.TEXT:
@@ -335,7 +323,17 @@ class Fisel {
 						}
 						
 					case DataType.JSON:
+						var info = [];
+						for (key in data.keys()) {
+							info = info.concat( Json.find( data.get( key ), point.attr( 'select' ) ) );
+							
+						}
 						
+						if (info.length > 0) {
+							point.replaceWith( info.join('').parse() );
+							matched.push( link );
+							
+						}
 						
 					case _:
 						// Implies DataType.HTML or DataType.XML

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -355,7 +355,24 @@ class Fisel {
 										node.setAttr( attribute.name, attribute.value );
 										
 									} else {
-										node.setAttr( attribute.name, node.attr( attribute.name ) + ' ' + attribute.value );
+										var separator = ' ';
+										var space = 0;
+										var dash = 0;
+										
+										for (char in node.attr( attribute.name ).split('')) switch (char) {
+											case ' ': space++;
+											case '-': dash++;
+											case _:
+										}
+										
+										if (space < dash) separator = '-';
+										
+										var nodeParts = node.attr( attribute.name ).split( separator );
+										var pointParts = attribute.value.split( separator ).filter( function(s) {
+											return nodeParts.indexOf( s ) == -1;
+										} );
+										
+										node.setAttr( attribute.name, nodeParts.concat( pointParts ).join( separator ) );
 										
 									}
 									

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -59,7 +59,7 @@ using sys.FileSystem;
 	public var REMOVE = 'remove';
 }
 
-@:enum private abstract Data(String) from String to String {
+@:forward @:enum private abstract Data(String) from String to String {
 	public var TARGET = 'data-target';
 	public var TYPE = 'data-type';
 }

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -53,7 +53,7 @@ using sys.FileSystem;
 	public var TEXT = 'plain';
 }
 
-@:forward @:enum abstract DataAction(String) from String to String {
+@:forward @:enum abstract DataTarget(String) from String to String {
 	public var COPY = 'copy';	// default
 	public var REMOVE = 'remove';
 }
@@ -85,7 +85,7 @@ class Fisel {
 	
 	private static var _ignore:Array<String> = ['select', 'data-type'];
 	private static var _targets:Array<String> = [DataType.TEXT, DataType.JSON, DataType.HTML];
-	private static var _actions:Array<String> = [DataAction.COPY, DataAction.REMOVE];
+	private static var _actions:Array<String> = [DataTarget.COPY, DataTarget.REMOVE];
 	
 	/**
 	 * Goes through the `parent`'s referrers link list
@@ -298,7 +298,7 @@ class Fisel {
 		var parser:SelectorParser = new SelectorParser();
 		var matched:Array<Link> = [];
 		var dataType:MediaType;
-		var dataAction:DataAction;
+		var dataAction:DataTarget;
 		var nodes:DOMCollection;
 		
 		for (link in links) if (!link.cycle) {
@@ -310,7 +310,7 @@ class Fisel {
 				selector = parser.toTokens( ByteData.ofString( point.attr( 'select' ) ), 'fisel-insert' );
 				
 				dataType = point.attr( 'data-type' ) != '' ? point.attr( 'data-type' ).toLowerCase() : 'text/html';
-				dataAction = point.attr( 'data-action' ) != '' ? point.attr( 'data-action' ).toLowerCase() : DataAction.COPY;
+				dataAction = point.attr( 'data-target' ) != '' ? point.attr( 'data-target' ).toLowerCase() : DataTarget.COPY;
 				
 				if (dataType.isText) switch (dataType.subtype) {
 					case DataType.TEXT:
@@ -350,7 +350,7 @@ class Fisel {
 					
 				}
 				
-				if (dataAction == DataAction.REMOVE) nodes.remove();
+				if (dataAction == DataTarget.REMOVE) nodes.remove();
 				
 			}
 			

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -341,7 +341,7 @@ class Fisel {
 						}
 						
 					case _:
-						// Implies DataType.HTML or DataType.XML
+						// Implies Source.HTML or Source.XML
 						if (isID( selector )) {
 							id = getID( selector );
 							

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -358,11 +358,13 @@ class Fisel {
 										var nodeAttribute = node.attr( attribute.name );
 										var separator = findSeparator( nodeAttribute );
 										var nodeParts = nodeAttribute.split( separator );
-										var pointParts = attribute.value.split( separator ).filter( function(s) {
-											return nodeParts.indexOf( s ) == -1;
-										} );
 										
-										node.setAttr( attribute.name, nodeParts.concat( pointParts ).join( separator ) );
+										node.setAttr( 
+											attribute.name, 
+											nodeParts.concat( attribute.value.split( separator ).filter( function(s) {
+												return nodeParts.indexOf( s ) == -1;
+											} ) ).join( separator ) 
+										);
 										
 									}
 									

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -28,19 +28,19 @@ using sys.FileSystem;
  */
 
  /**
-  * - [x] Allow root uri to be set via `<base href="path/to/directory" />`.
-  * - [x] Root uri can be relative.
-  * - [x] Root uri can be absolute.
+  * - [ ] Allow root uri to be set via `<base href="path/to/directory" />`.
+  * - [ ] Root uri can be relative.
+  * - [ ] Root uri can be absolute.
   * - [x] Allow resources to be loaded from the filesystem.
   * - [ ] Allow resources to be loaded from the web.
   * - [x] Make sure all resource uris end with `html` or `htm`.
   * - [x] Each loaded resource is a Fisel instance.
 	* - [x] Allow HTML not wrapped in `<template></template>`.
-	* - [x] Automatically wrap any HTML not wrapped in `<template></template>`.
-  * - [x] Imported HTML replaces a `<content select="css"/>` which was selected by the `select` attribute.
+	* - [x] Automatically wrap all HTML in `<fisel></fisel>`.
+  * - [x] Imported HTML replaces a `<content select="#css"/>` which was selected by the `select` attribute.
   * - [x] Any unmatched selectors then search the document in its current state for a match.
   * - [x] Attributes on `<content id="1" data-name="Skial" /> which don't exist on the imported HTML are transfered over.
-  * - [x] Transfered attributes which match by name will have the value added only if it doesnt exist, space separated to the end.
+  * - [x] Transfered attributes which match by name will have the value added only if it doesnt exist, added to the end.
   * - [x] Detect if attributes value is space or dashed separated and use the correct character when appending new values. Default is space.
   * - [x] Remove `<link rel="import" />` when `Fisel::build` has been run.
   */
@@ -298,11 +298,8 @@ class Fisel {
 	 * will match with `select="#File"`.
 	 */
 	private function handleInsertions():Void {
-		var id:String = '';
 		var fisel:Fisel = null;
-		var selector:CssSelectors;
 		var insertionPoints:DOMCollection = null;
-		var parser:SelectorParser = new SelectorParser();
 		var matched:Array<Link> = [];
 		var mediaType:MediaType;
 		var dataAction:Action;
@@ -343,12 +340,12 @@ class Fisel {
 						
 					case _:
 						// Implies Source.HTML or Source.XML
-						selector = parser.toTokens( ByteData.ofString( point.attr( 'select' ) ), 'fisel-insert' );
+						var parser:SelectorParser = new SelectorParser();
+						var selector = parser.toTokens( ByteData.ofString( point.attr( 'select' ) ), 'fisel-insert' );
 						
 						if (isID( selector )) {
-							id = getID( selector );
 							
-							if (link.location.withoutDirectory().indexOf( id ) > -1) {
+							if (link.location.withoutDirectory().indexOf( getID( selector ) ) > -1) {
 								var clone = fisel.document.children().clone();
 								
 								transferAttributes( clone.getNode(), point.attributes );

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -88,7 +88,7 @@ class Fisel {
 		
 	}
 	
-	private static var _ignore:Array<String> = ['select', 'data-type'];
+	private static var _ignore:Array<String> = ['select', Data.TYPE, Data.TARGET];
 	private static var _targets:Array<String> = [Source.TEXT, Source.HTML, Source.JSON];
 	private static var _actions:Array<String> = [Action.COPY, Action.REMOVE];
 	
@@ -346,7 +346,22 @@ class Fisel {
 							id = getID( selector );
 							
 							if (link.location.withoutDirectory().indexOf( id ) > -1) {
-								point.replaceWith( fisel.document.children().clone() );
+								var clone = fisel.document.children().clone();
+								
+								for (attribute in point.attributes) if (_ignore.indexOf( attribute.name ) == -1) {
+									var node = clone.getNode();
+									
+									if (node.attr( attribute.name ) == '') {
+										node.setAttr( attribute.name, attribute.value );
+										
+									} else {
+										node.setAttr( attribute.name, node.attr( attribute.name ) + ' ' + attribute.value );
+										
+									}
+									
+								}
+								
+								point.replaceWith( clone );
 								matched.push( link );
 								
 							}

--- a/src/Fisel.hx
+++ b/src/Fisel.hx
@@ -320,11 +320,11 @@ class Fisel {
 				
 				if (mediaType.isText) switch (mediaType.subtype) {
 					case Source.TEXT:
-						var text = fisel.document.find( point.attr( 'select' ) );
-						if (text.length > 0) {
-							point.replaceWith( text.text().parse() );
+						var node = fisel.document.find( point.attr( 'select' ) );
+						if (node.length > 0) {
+							point.replaceWith( node.text().parse() );
 							matched.push( link );
-							nodes.addCollection( text );
+							nodes.addCollection( node );
 							
 						}
 						
@@ -351,28 +351,7 @@ class Fisel {
 							if (link.location.withoutDirectory().indexOf( id ) > -1) {
 								var clone = fisel.document.children().clone();
 								
-								for (attribute in point.attributes) if (_ignore.indexOf( attribute.name ) == -1) {
-									var node = clone.getNode();
-									
-									if (node.attr( attribute.name ) == '') {
-										node.setAttr( attribute.name, attribute.value );
-										
-									} else {
-										var nodeAttribute = node.attr( attribute.name );
-										var separator = findSeparator( nodeAttribute );
-										var nodeParts = nodeAttribute.split( separator );
-										
-										node.setAttr( 
-											attribute.name, 
-											nodeParts.concat( attribute.value.split( separator ).filter( function(s) {
-												return nodeParts.indexOf( s ) == -1;
-											} ) ).join( separator ) 
-										);
-										
-									}
-									
-								}
-								
+								transferAttributes( clone.getNode(), point.attributes );
 								point.replaceWith( clone );
 								matched.push( link );
 								
@@ -408,6 +387,29 @@ class Fisel {
 		}
 		
 		return space < dash ? '-' : ' ';
+	}
+	
+	private function transferAttributes(target:DOMNode, attributes:Iterable<{name:String, value:String}>):Void {
+		for (attribute in attributes) if (_ignore.indexOf( attribute.name ) == -1) {
+			
+			if (target.attr( attribute.name ) == '') {
+				target.setAttr( attribute.name, attribute.value );
+				
+			} else {
+				var nodeAttribute = target.attr( attribute.name );
+				var separator = findSeparator( nodeAttribute );
+				var nodeParts = nodeAttribute.split( separator );
+				
+				target.setAttr( 
+					attribute.name, 
+					nodeParts.concat( attribute.value.split( separator ).filter( function(s) {
+						return nodeParts.indexOf( s ) == -1;
+					} ) ).join( separator ) 
+				);
+				
+			}
+			
+		}
 	}
 	
 	private function isCombinator(selector:CssSelectors):Bool {

--- a/src/LibRunner.hx
+++ b/src/LibRunner.hx
@@ -53,6 +53,12 @@ class LibRunner extends Ioe implements Klas {
 	@alias('p')
 	public var pretty:Bool = false;
 	
+	/**
+	 * An array of json files.
+	 */
+	@alias('d')
+	public var data:Array<String> = [];
+	
 	public function new(args:Array<String>) {
 		super();
 		@:cmd _;
@@ -67,6 +73,12 @@ class LibRunner extends Ioe implements Klas {
 		
 		if (content != '') {
 			var fisel = new Fisel();
+			
+			for (json in data) if ((json = json.normalize()).exists() && !json.isDirectory()) {
+				fisel.data.set( json, haxe.Json.parse( File.getContent( json ) ) );
+				
+			}
+			
 			fisel.document =  content.parse();
 			fisel.location = input == null ? Sys.getCwd() : input;
 			fisel.linkMap = new StringMap();


### PR DESCRIPTION
- Add `data-type` attribute which takes a mime/media type as its value. Currently understood values are: 
  - `text/html` _default_
  - `text/xml` treated the same as `text/html`
  - `text/json` tells the selector to search json data held in `Fisel.data` string map.
  - `text/plain` tells fisel to replace `<content />` with matched elements text value.
- Add `data-target` attribute which takes one of two values, `remove` or `copy`. `copy` is the _default_. `remove` will remove the matched element and is removed only if `data-type="text/plain"` is set.
- Any attribute that is not `select`, `data-type` or `data-target` will be transferred to the matched element/s.
  - If the element has a matching attribute, any value not on the target element will be transferred. e.g. `<content class="a b c" />` matching `<div class="b a">` will become `<div class="b a c">`.
  - Only space ` `and dash`-` are automatically detected on target element attributes, which is then used to append new values. The implementation is crude.
- JSON data has to be loaded into `Fisel.data` `StringMap<Dynamic>`. Fisel's LibRunner.hx does this through the `-d` command. Use `fisel -?` to see more info.
